### PR TITLE
Add news item: NDMC HPVsim modelling workshop, Sep 2023

### DIFF
--- a/src/news/2023-09-23-ndmc-workshop.md
+++ b/src/news/2023-09-23-ndmc-workshop.md
@@ -1,0 +1,9 @@
+---
+title: HPVsim modelling workshop at NDMC, IIT Bombay
+date: 2023-09-23
+blurb: >-
+  HPVsim modelling workshop held over September 20-22, 2023, at the National
+  Disease Modelling Consortium (NDMC), Indian Institute of Technology Bombay.
+kind: other
+href: https://docs.google.com/document/d/1WqUW_x-DPEF8iCImlumF6rAGoayrguVY/edit
+---


### PR DESCRIPTION
## Summary
- Adds a News entry for the HPVsim modelling workshop held Sep 20-22, 2023 at NDMC, IIT Bombay, linking to the workshop agenda.